### PR TITLE
LogEntry.Scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can find an explanation on the advantages of using this library and the impo
 The logger factory exposes a property `Sink` to access the sink that collects the logs. The sink exposes a property `LogEntries` that enumerates all the captured logs.
 Each entry exposes all the relevant property for a log.
 
-For example, to test with xUnit that a single log has been emitted and it had a specific message:
+For example, to test with xUnit that a single log has been emitted and it has a specific message:
 
 ```csharp
 var log = Assert.Single(loggerFactory.Sink.LogEntries);
@@ -102,20 +102,22 @@ Assert.Equal("The answer is 42", log.Message);
 
 ### Assert scopes
 
-The logger factory exposes a property `Sink` to access the sink that collects the logs. The sink exposes a property `Scopes` that enumerates all the captured scopes.
+Each log entry exposes a property `Scopes` to have the scopes active for the particular logger captured with that entry.
+_Note that the scopes of a log entry are local to a specific logger and async context._
+
+```csharp
+var log = Assert.Single(loggerFactory.Sink.LogEntries);
+var log = Assert.Single(log.Scopes);
+Assert.Equal("This scope's answer is 42", scope.Message);
+```
+
+It is also possible to get all the scopes generated across all loggers. The logger factory exposes a property `Sink` to access the sink that collects the logs. The sink exposes a property `Scopes` that enumerates all the captured scopes.
 
 For example, to test with xUnit that a single scope has been emitted and it had a specific message:
 
 ```csharp
 var scope = Assert.Single(loggerFactory.Sink.Scopes);
 Assert.Equal("I'm in the GET scope", scope.Message);
-```
-
-There is also a property `Scope` in each log entry to have the scope captured with that entry, however this only support the most inner scope and doesn't track it across different loggers.
-
-```csharp
-var log = Assert.Single(loggerFactory.Sink.LogEntries);
-Assert.Equal("This scope's answer is 42", log.Scope.Message);
 ```
 
 ### Assert log original format

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can find an explanation on the advantages of using this library and the impo
   - [Full example](#full-example-3)
 - [NLog compatibility using NLog.Web.AspNetCore](#nlog-compatibility-using-nlogwebaspnetcore)
   - [Full example](#full-example-4)
+- [Upgrade from 0.6](#upgrade-from-06)
 - [Upgrade from 0.4 and below](#upgrade-from-04-and-below)
   - [Upgrade of ASP.NET Core Integration Tests](#upgrade-of-aspnet-core-integration-tests)
 
@@ -503,6 +504,21 @@ Simply follow the main instruction as the fact that you are plugging NLog as the
 
 See [LoggingTest](samples/current/NLog/SampleWebApplicationNLog.IntegrationTests/LoggingTest.cs) or
 [LoggingTestWithInjectedFactory](samples/current/NLog/SampleWebApplicationNLog.IntegrationTests/LoggingTestWithInjectedFactory.cs).
+
+## Upgrade from 0.6
+
+If you follow the deprecation warnings on `LogEntry.Scope`, you will be able to easily migrate to the new `LogEntry.Scopes`, which contains all the scopes active for the specific log entry, which means the scopes that were active for the particular logger and async context when the log entry had been generated.
+
+Also notes that the `LogEntry.Scope` now returns the inner scope for the speicifc logger and async context, instead of the previously unexpected behaviour of returning the latest scope created on the specific logger, even if not active for that entry.
+
+Asserting scope.
+
+```csharp
+Assert.Equal("I'm in the GET scope", log.Scope.Message);
+// become
+var scope = Assert.Single(log.Scopes);
+Assert.Equal("I'm in the GET scope", scope.Message);
+```
 
 ## Upgrade from 0.4 and below
 

--- a/samples/2.1/SampleWebApplication2_1.IntegrationTests/LoggingTest.cs
+++ b/samples/2.1/SampleWebApplication2_1.IntegrationTests/LoggingTest.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using MELT;
-using MELT.Xunit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
@@ -9,13 +8,13 @@ namespace SampleWebApplication2_1.IntegrationTests
 {
     public class LoggingTest : IClassFixture<WebApplicationFactory<Startup>>
     {
-        private readonly ITestSink _sink;
         private readonly WebApplicationFactory<Startup> _factory;
 
         public LoggingTest(WebApplicationFactory<Startup> factory)
         {
-            _sink = MELTBuilder.CreateTestSink(options => options.FilterByNamespace(nameof(SampleWebApplication2_1)));
-            _factory = factory.WithWebHostBuilder(builder => builder.UseTestLogging(_sink));
+            _factory = factory.WithWebHostBuilder(
+                builder => builder.UseTestLogging(
+                    options => options.FilterByNamespace(nameof(SampleWebApplication2_1))));
         }
 
         [Fact]
@@ -27,7 +26,7 @@ namespace SampleWebApplication2_1.IntegrationTests
             await _factory.CreateDefaultClient().GetAsync("/");
 
             // Assert
-            var log = Assert.Single(_sink.LogEntries);
+            var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
             // Assert the message rendered by a default formatter
             Assert.Equal("Hello World!", log.Message);
         }
@@ -41,9 +40,9 @@ namespace SampleWebApplication2_1.IntegrationTests
             await _factory.CreateDefaultClient().GetAsync("/");
 
             // Assert
-            var log = Assert.Single(_sink.LogEntries);
+            var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
             // Assert specific parameters in the log entry
-            LogValuesAssert.Contains("place", "World", log);
+            LoggingAssert.Contains("place", "World", log.Properties);
         }
 
         [Fact]
@@ -55,9 +54,10 @@ namespace SampleWebApplication2_1.IntegrationTests
             await _factory.CreateDefaultClient().GetAsync("/");
 
             // Assert
-            var log = Assert.Single(_sink.LogEntries);
+            var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
 
         [Fact]
@@ -69,9 +69,10 @@ namespace SampleWebApplication2_1.IntegrationTests
             await _factory.CreateDefaultClient().GetAsync("/");
 
             // Assert
-            var log = Assert.Single(_sink.LogEntries);
+            var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert specific parameters in the log scope
-            LogValuesAssert.Contains("name", "GET", log.Scope);
+            LoggingAssert.Contains("name", "GET", scope.Properties);
         }
 
         [Fact]
@@ -83,7 +84,7 @@ namespace SampleWebApplication2_1.IntegrationTests
             await _factory.CreateDefaultClient().GetAsync("/");
 
             // Assert
-            var scope = Assert.Single(_sink.Scopes);
+            var scope = Assert.Single(_factory.GetTestLoggerSink().Scopes);
             // Assert the scope rendered by a default formatter
             Assert.Equal("I'm in the GET scope", scope.Message);
         }
@@ -97,9 +98,9 @@ namespace SampleWebApplication2_1.IntegrationTests
             await _factory.CreateDefaultClient().GetAsync("/");
 
             // Assert
-            var scope = Assert.Single(_sink.Scopes);
+            var scope = Assert.Single(_factory.GetTestLoggerSink().Scopes);
             // Assert specific parameters in the log scope
-            LogValuesAssert.Contains("name", "GET", scope);
+            LoggingAssert.Contains("name", "GET", scope.Properties);
         }
     }
 }

--- a/samples/2.1/SampleWebApplication2_1.IntegrationTests/LoggingTestWithInjectedFactory.cs
+++ b/samples/2.1/SampleWebApplication2_1.IntegrationTests/LoggingTestWithInjectedFactory.cs
@@ -14,7 +14,7 @@ namespace SampleWebApplication2_1.IntegrationTests
             _factory = factory;
             // In this case, the factory will be reused for all tests, so the sink will be shared as well.
             // We can clear the sink before each test execution, as xUnit will not run this tests in parallel.
-            if (_factory.TryGetTestSink(out var testSink)) testSink!.Clear();  // or simply testSink.Clear(); when not using Nullable Reference Types
+            if (_factory.TryGetTestLoggerSink(out var testSink)) testSink!.Clear();  // or simply testSink.Clear(); when not using Nullable Reference Types
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace SampleWebApplication2_1.IntegrationTests
             await _factory.CreateDefaultClient().GetAsync("/");
 
             // Assert
-            var log = Assert.Single(_factory.GetTestSink().LogEntries);
+            var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
             // Assert the message rendered by a default formatter
             Assert.Equal("Hello World!", log.Message);
         }
@@ -40,9 +40,10 @@ namespace SampleWebApplication2_1.IntegrationTests
             await _factory.CreateDefaultClient().GetAsync("/");
 
             // Assert
-            var log = Assert.Single(_factory.GetTestSink().LogEntries);
+            var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
     }
 

--- a/samples/3.1/SampleWebApplication3_1.IntegrationTests/LoggingTest.cs
+++ b/samples/3.1/SampleWebApplication3_1.IntegrationTests/LoggingTest.cs
@@ -94,8 +94,9 @@ namespace SampleWebApplication3_1.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
 
         [Fact]
@@ -108,8 +109,9 @@ namespace SampleWebApplication3_1.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert specific parameters in the log scope
-            LoggingAssert.Contains("name", "GET", log.Scope.Properties);
+            LoggingAssert.Contains("name", "GET", scope.Properties);
         }
 
         [Fact]

--- a/samples/current/NLog/SampleWebApplicationNLog.IntegrationTests/LoggingTest.cs
+++ b/samples/current/NLog/SampleWebApplicationNLog.IntegrationTests/LoggingTest.cs
@@ -94,8 +94,9 @@ namespace SampleWebApplicationNLog.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
 
         [Fact]
@@ -108,8 +109,9 @@ namespace SampleWebApplicationNLog.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert specific parameters in the log scope
-            LoggingAssert.Contains("name", "GET", log.Scope.Properties);
+            LoggingAssert.Contains("name", "GET", scope.Properties);
         }
 
         [Fact]

--- a/samples/current/NLog/SampleWebApplicationNLog.IntegrationTests/LoggingTestWithInjectedFactory.cs
+++ b/samples/current/NLog/SampleWebApplicationNLog.IntegrationTests/LoggingTestWithInjectedFactory.cs
@@ -43,8 +43,9 @@ namespace SampleWebApplicationNLog.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
 
         [Fact]

--- a/samples/current/SampleLibrary.Tests/MoreTest.cs
+++ b/samples/current/SampleLibrary.Tests/MoreTest.cs
@@ -145,7 +145,8 @@ namespace SampleLibrary.Tests
 
             // Assert
             var log = Assert.Single(loggerFactory.Sink.LogEntries);
-            Assert.Equal("This scope's answer is 42", log.Scope.Message);
+            var scope = Assert.Single(log.Scopes);
+            Assert.Equal("This scope's answer is 42", scope.Message);
         }
 
         [Fact]
@@ -164,7 +165,8 @@ namespace SampleLibrary.Tests
             var log = Assert.Single(loggerFactory.Sink.LogEntries);
             Assert.Equal("This log entry is at trace level", log.Message);
             LoggingAssert.Contains("level", "trace", log.Properties);
-            LoggingAssert.Contains("foo", "bar", log.Scope.Properties);
+            var scope = Assert.Single(log.Scopes);
+            LoggingAssert.Contains("foo", "bar", scope.Properties);
         }
     }
 }

--- a/samples/current/SampleLibrary.Tests/SampleTest.cs
+++ b/samples/current/SampleLibrary.Tests/SampleTest.cs
@@ -60,24 +60,6 @@ namespace SampleLibrary.Tests
         }
 
         [Fact]
-        public void DoSomethingLogsScope()
-        {
-            // Arrange
-            var loggerFactory = TestLoggerFactory.Create();
-
-            var logger = loggerFactory.CreateLogger<Sample>();
-            var sample = new Sample(logger);
-
-            // Act
-            sample.DoSomething();
-
-            // Assert
-            var log = Assert.Single(loggerFactory.Sink.LogEntries);
-            // Assert the message rendered by a default formatter
-            Assert.Single("The answer is 42", log.Scopes);
-        }
-
-        [Fact]
         public void DoExceptionalLogsException()
         {
             // Arrange

--- a/samples/current/SampleLibrary.Tests/SampleTest.cs
+++ b/samples/current/SampleLibrary.Tests/SampleTest.cs
@@ -60,6 +60,24 @@ namespace SampleLibrary.Tests
         }
 
         [Fact]
+        public void DoSomethingLogsScope()
+        {
+            // Arrange
+            var loggerFactory = TestLoggerFactory.Create();
+
+            var logger = loggerFactory.CreateLogger<Sample>();
+            var sample = new Sample(logger);
+
+            // Act
+            sample.DoSomething();
+
+            // Assert
+            var log = Assert.Single(loggerFactory.Sink.LogEntries);
+            // Assert the message rendered by a default formatter
+            Assert.Single("The answer is 42", log.Scopes);
+        }
+
+        [Fact]
         public void DoExceptionalLogsException()
         {
             // Arrange

--- a/samples/current/SampleWebApplication.IntegrationTests/LoggingTest.cs
+++ b/samples/current/SampleWebApplication.IntegrationTests/LoggingTest.cs
@@ -96,8 +96,9 @@ namespace SampleWebApplication.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
 
         [Fact]
@@ -111,8 +112,9 @@ namespace SampleWebApplication.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert specific parameters in the log scope
-            LoggingAssert.Contains("name", "GET", log.Scope.Properties);
+            LoggingAssert.Contains("name", "GET", scope.Properties);
         }
 
         [Fact]

--- a/samples/current/SampleWebApplication.IntegrationTests/LoggingTest.cs
+++ b/samples/current/SampleWebApplication.IntegrationTests/LoggingTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -85,6 +86,7 @@ namespace SampleWebApplication.IntegrationTests
         }
 
         [Fact]
+        [Obsolete("LogEntry.Scope")]
         public async Task ShouldUseScope()
         {
             // Arrange
@@ -99,6 +101,7 @@ namespace SampleWebApplication.IntegrationTests
         }
 
         [Fact]
+        [Obsolete("LogEntry.Scope")]
         public async Task ShouldUseScopeWithParameter()
         {
             // Arrange

--- a/samples/current/SampleWebApplication.IntegrationTests/LoggingTestWithInjectedFactory.cs
+++ b/samples/current/SampleWebApplication.IntegrationTests/LoggingTestWithInjectedFactory.cs
@@ -43,8 +43,9 @@ namespace SampleWebApplication.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
 
         [Fact]

--- a/samples/current/SampleWebApplication/Properties/launchSettings.json
+++ b/samples/current/SampleWebApplication/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -12,7 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -21,7 +21,7 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/samples/current/SampleWebApplication/Startup.cs
+++ b/samples/current/SampleWebApplication/Startup.cs
@@ -53,6 +53,32 @@ namespace SampleWebApplication
                         await context.Response.WriteAsync("Hello World!");
                     }
                 });
+
+                endpoints.MapGet("/incorrectlyDisposedScopes", async context =>
+                {
+                    var logger = context.RequestServices.GetRequiredService<ILogger<Startup>>();
+
+                    using (var a = logger.BeginScope("A"))
+                    {
+                        var b = logger.BeginScope("B");
+                        var c = logger.BeginScope("C");
+
+                        logger.LogInformation("Hello {place}!", "World");
+
+                        b.Dispose();
+
+                        logger.LogInformation("Hello {place}!", "World");
+
+                        c.Dispose();
+
+                        logger.LogInformation("Hello {place}!", "World");
+
+                        context.Response.ContentType = "text/plain";
+                        await context.Response.WriteAsync("Hello World!");
+                    }
+
+                    logger.LogInformation("Hello {place}!", "World");
+                });
             });
         }
     }

--- a/samples/current/SampleWebApplication/appsettings.json
+++ b/samples/current/SampleWebApplication/appsettings.json
@@ -4,6 +4,9 @@
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true
     }
   },
   "AllowedHosts": "*"

--- a/samples/current/serilog/SampleWebApplicationSerilog.IntegrationTests/LoggingTest.cs
+++ b/samples/current/serilog/SampleWebApplicationSerilog.IntegrationTests/LoggingTest.cs
@@ -55,8 +55,9 @@ namespace SampleWebApplicationSerilog.Tests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
 
         [Fact]
@@ -69,8 +70,9 @@ namespace SampleWebApplicationSerilog.Tests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert specific parameters in the log scope
-            LoggingAssert.Contains("name", "GET", log.Scope.Properties);
+            LoggingAssert.Contains("name", "GET", scope.Properties);
         }
 
         [Fact]

--- a/samples/current/serilog/SampleWebApplicationSerilog.IntegrationTests/LoggingTestWithInjectedFactory.cs
+++ b/samples/current/serilog/SampleWebApplicationSerilog.IntegrationTests/LoggingTestWithInjectedFactory.cs
@@ -45,8 +45,9 @@ namespace SampleWebApplicationSerilog.Tests
 
             // Assert
             var log = Assert.Single(_factory.GetTestLoggerSink().LogEntries);
+            var scope = Assert.Single(log.Scopes);
             // Assert the scope rendered by a default formatter
-            Assert.Equal("I'm in the GET scope", log.Scope.Message);
+            Assert.Equal("I'm in the GET scope", scope.Message);
         }
 
         [Fact]

--- a/samples/current/serilog/SampleWebApplicationSerilogAlternate.IntegrationTests/LoggingTest.cs
+++ b/samples/current/serilog/SampleWebApplicationSerilogAlternate.IntegrationTests/LoggingTest.cs
@@ -66,7 +66,7 @@ namespace SampleWebApplicationSerilogAlternate.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetSerilogTestLoggerSink().LogEntries);
-            var scope = Assert.Single(log.Scope);
+            var scope = Assert.Single(log.Scopes);
             Assert.Equal(new ScalarValue("I'm in the GET scope"), scope);
 
         }
@@ -83,14 +83,14 @@ namespace SampleWebApplicationSerilogAlternate.IntegrationTests
             var log = Assert.Single(_factory.GetSerilogTestLoggerSink().LogEntries);
 
             // Assert the scopes
-            Assert.Collection(log.Scope,
+            Assert.Collection(log.Scopes,
                 x => Assert.Equal(new ScalarValue("A top level scope"), x),
                 x => Assert.Equal(new ScalarValue("I'm in the GET scope"), x)
             );
             // or
-            Assert.Equal(2, log.Scope.Count);
-            Assert.Equal(new ScalarValue("A top level scope"), log.Scope[0]);
-            Assert.Equal(new ScalarValue("I'm in the GET scope"), log.Scope[1]);
+            Assert.Equal(2, log.Scopes.Count);
+            Assert.Equal(new ScalarValue("A top level scope"), log.Scopes[0]);
+            Assert.Equal(new ScalarValue("I'm in the GET scope"), log.Scopes[1]);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace SampleWebApplicationSerilogAlternate.IntegrationTests
             // Assert
             var log = Assert.Single(_factory.GetSerilogTestLoggerSink().LogEntries);
             // If the scope is a dictionary, it will only add the properties, not a scope
-            Assert.Empty(log.Scope);
+            Assert.Empty(log.Scopes);
             LoggingAssert.Contains("foo", "bar", log.Properties);
             LoggingAssert.Contains("answer", 42, log.Properties);
         }

--- a/samples/current/serilog/SampleWebApplicationSerilogAlternate.IntegrationTests/LoggingTestWithInjectedFactory.cs
+++ b/samples/current/serilog/SampleWebApplicationSerilogAlternate.IntegrationTests/LoggingTestWithInjectedFactory.cs
@@ -45,7 +45,7 @@ namespace SampleWebApplicationSerilogAlternate.IntegrationTests
 
             // Assert
             var log = Assert.Single(_factory.GetSerilogTestLoggerSink().LogEntries);
-            var scope = Assert.Single(log.Scope);
+            var scope = Assert.Single(log.Scopes);
             var scopeValue = Assert.IsType<ScalarValue>(scope).Value;
             Assert.Equal("I'm in the GET scope", scopeValue);
         }

--- a/src/MELT.Serilog/SerilogLogEntry.cs
+++ b/src/MELT.Serilog/SerilogLogEntry.cs
@@ -45,9 +45,12 @@ namespace MELT
             return Constants.NullString;
         }
 
-        public IReadOnlyList<LogEventPropertyValue> Scope => _scope ??= GetSerilogScope();
+        [Obsolete("The recommended alternative is " + nameof(Scopes) + ".")]
+        public IReadOnlyList<LogEventPropertyValue> Scope => _scope ??= GetSerilogScopes();
 
-        private IReadOnlyList<LogEventPropertyValue> GetSerilogScope()
+        public IReadOnlyList<LogEventPropertyValue> Scopes => _scope ??= GetSerilogScopes();
+
+        private IReadOnlyList<LogEventPropertyValue> GetSerilogScopes()
         {
             var scopeSequence = Properties.SingleOrDefault(x => x.Key == "Scope").Value as SequenceValue;
             return scopeSequence?.Elements ?? _emptyProperties;

--- a/src/MELT/Helpers/IInternalTestSink.cs
+++ b/src/MELT/Helpers/IInternalTestSink.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 
 namespace MELT
 {
@@ -22,9 +21,7 @@ namespace MELT
 
         void Write(WriteContext context);
 
-        IDisposable BeginScope(BeginScopeContext context);
-
-        IEnumerable<BeginScope> CurrentScopeData { get; }
+        void BeginScope(BeginScopeContext context);
 
         void Clear();
     }

--- a/src/MELT/Helpers/LogEntry.cs
+++ b/src/MELT/Helpers/LogEntry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 
 namespace MELT
@@ -58,16 +59,16 @@ namespace MELT
         public string Format => OriginalFormat;
 
         /// <summary>
-        /// The closer scope for this log entry captured by the current logger.
+        /// The latest scope initiated on the current logger at the time of this log entry being captured, not necessarily active.
         /// </summary>
         /// <remarks>This does not track scopes across loggers. For more general scope testing use <see cref="ITestLoggerSink.Scopes"/>.</remarks>
-        [Obsolete("The recommended alternative is " + nameof(FullScope) + ".")]
+        [Obsolete("The recommended alternative is " + nameof(Scopes) + ".")]
         public Scope Scope => new Scope(_entry.Scope);
 #pragma warning restore CS0612 // Type or member is obsolete
 
         /// <summary>
-        /// The full scope
+        /// The scopes for this log entry.
         /// </summary>
-        public IEnumerable<IScope> FullScope => _entry.FullScope;
+        public IEnumerable<Scope> Scopes => _entry.Scopes.Select(s => new Scope(s));
     }
 }

--- a/src/MELT/Helpers/LogEntry.cs
+++ b/src/MELT/Helpers/LogEntry.cs
@@ -59,9 +59,8 @@ namespace MELT
         public string Format => OriginalFormat;
 
         /// <summary>
-        /// The latest scope initiated on the current logger at the time of this log entry being captured, not necessarily active.
+        /// The inner scope for this log entry.
         /// </summary>
-        /// <remarks>This does not track scopes across loggers. For more general scope testing use <see cref="ITestLoggerSink.Scopes"/>.</remarks>
         [Obsolete("The recommended alternative is " + nameof(Scopes) + ".")]
         public Scope Scope => new Scope(_entry.Scope);
 #pragma warning restore CS0612 // Type or member is obsolete

--- a/src/MELT/Helpers/TestSinkOptions.cs
+++ b/src/MELT/Helpers/TestSinkOptions.cs
@@ -3,10 +3,13 @@ using Microsoft.Extensions.Logging;
 
 namespace MELT
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class TestLoggerOptions
     {
+#pragma warning disable CS0612 // Type or member is obsolete
         internal Func<WriteContext, bool>? WriteEnabled { get; set; }
         internal Func<BeginScopeContext, bool>? BeginEnabled { get; set; }
+#pragma warning restore CS0612 // Type or member is obsolete
 
         public TestLoggerOptions FilterByNamespace(string namespacePrefix)
         {
@@ -30,7 +33,9 @@ namespace MELT
             return this;
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         private void AddWriteEnabledRule(Func<WriteContext, bool> func)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             if (WriteEnabled is null)
             {
@@ -43,7 +48,9 @@ namespace MELT
             }
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         private void AddBeginEnabledRule(Func<BeginScopeContext, bool> func)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             if (BeginEnabled is null)
             {
@@ -56,4 +63,5 @@ namespace MELT
             }
         }
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/MELT/TestLogger.cs
+++ b/src/MELT/TestLogger.cs
@@ -65,7 +65,7 @@ namespace MELT
             while (scope != null)
             {
                 scopes.Push(scope.State);
-                scope = scope.Parent;                
+                scope = scope.Parent;
             }
 
             return scopes;

--- a/src/MELT/TestLogger.cs
+++ b/src/MELT/TestLogger.cs
@@ -53,7 +53,7 @@ namespace MELT
             var scopes = GetScopes();
 
 #pragma warning disable CS0612 // Type or member is obsolete
-            _sink.Write(new WriteContext(logLevel, eventId, state, exception, _currentScope, Name, message, scopes));
+            _sink.Write(new WriteContext(logLevel, eventId, state, exception, _currentScope.Value?.State, Name, message, scopes));
 #pragma warning restore CS0612 // Type or member is obsolete
         }
 

--- a/src/MELT/TestLogger.cs
+++ b/src/MELT/TestLogger.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace MELT
@@ -12,11 +15,7 @@ namespace MELT
 #pragma warning disable CS0612 // Type or member is obsolete
         private readonly ITestSink _sink;
 
-        /// <summary>
-        /// The most recent scope, even if it has been exited.
-        /// </summary>
-        [Obsolete]
-        private object? _scope;
+        private readonly AsyncLocal<TestScope> _currentScope = new AsyncLocal<TestScope>();
 
         public TestLogger(string name, ITestSink sink)
         {
@@ -29,8 +28,15 @@ namespace MELT
 
         public IDisposable BeginScope<TState>(TState state)
         {
-            _scope = state;
-            return _sink.BeginScope(new BeginScopeContext(Name, state));
+#pragma warning disable CS0612 // Type or member is obsolete
+            _sink.BeginScope(new BeginScopeContext(Name, state));
+
+            var parent = _currentScope.Value;
+            var newScope = new TestScope(this, state, parent);
+            _currentScope.Value = newScope;
+
+            return newScope;
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
@@ -44,12 +50,54 @@ namespace MELT
 
             var message = formatter(state, exception);
 
+            var scopes = GetScopes();
+
 #pragma warning disable CS0612 // Type or member is obsolete
-            _sink.Write(new WriteContext(logLevel, eventId, state, exception, _scope, Name, message, _sink.CurrentScopeData));
+            _sink.Write(new WriteContext(logLevel, eventId, state, exception, _currentScope, Name, message, scopes));
 #pragma warning restore CS0612 // Type or member is obsolete
         }
 
+        private IEnumerable<object?> GetScopes()
+        {
+            var scopes = new Stack<object?>();
+
+            var scope = _currentScope.Value;
+            while (scope != null)
+            {
+                scopes.Push(scope.State);
+                scope = scope.Parent;                
+            }
+
+            return scopes;
+        }
+
         public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        internal class TestScope : IDisposable
+        {
+            private readonly TestLogger _logger;
+            private bool _isDisposed;
+
+            internal TestScope(TestLogger logger, object? state, TestScope parent)
+            {
+                _logger = logger;
+                State = state;
+                Parent = parent;
+            }
+
+            public TestScope Parent { get; }
+
+            public object? State { get; }
+
+            public void Dispose()
+            {
+                if (!_isDisposed)
+                {
+                    _logger._currentScope.Value = Parent;
+                    _isDisposed = true;
+                }
+            }
+        }
     }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/MELT/TestSink.cs
+++ b/src/MELT/TestSink.cs
@@ -41,15 +41,6 @@ namespace MELT
         /// </summary>
         public IEnumerable<BeginScope> Scopes => BeginScopes.Select(x => new BeginScope(x));
 
-        /// <summary>
-        /// All the current scopes.
-        /// </summary>
-        public IEnumerable<BeginScope> CurrentScopeData => _currentScope.ScopeData;
-
-        private (IReadOnlyCollection<BeginScope> ScopeData, IReadOnlyCollection<TestScope> ActiveScopes) _currentScope = (new List<BeginScope>(), new List<TestScope>());
-
-        private readonly object _scopeLock = new { };
-
         public event Action<WriteContext>? MessageLogged;
 
         public event Action<BeginScopeContext>? ScopeStarted;
@@ -63,69 +54,19 @@ namespace MELT
             MessageLogged?.Invoke(context);
         }
 
-        public IDisposable BeginScope(BeginScopeContext context)
+        public void BeginScope(BeginScopeContext context)
         {
-            TestScope testScope;
-            lock (_scopeLock)
-            {
-                var oldScope = _currentScope;
-                testScope = new TestScope(this, oldScope);
-
-                //In principle, using Immutable collections here would prevent copying the collections
-                //But the number of scopes is low enough that it probably isn't worth the extra dependency
-                var newScopeData = oldScope.ScopeData.Prepend(new BeginScope(context)).ToList();
-
-                var newActiveScopes = oldScope.ActiveScopes.Append(testScope).ToList();
-                _currentScope = (newScopeData, newActiveScopes);
-            }
-
             if (BeginEnabled == null || BeginEnabled(context))
             {
                 _beginScopes.Enqueue(context);
             }
             ScopeStarted?.Invoke(context);
-
-            return testScope;
         }
 
         public void Clear()
         {
             _beginScopes = new ConcurrentQueue<BeginScopeContext>();
             _writes = new ConcurrentQueue<WriteContext>();
-        }
-
-        private void EndScope(TestScope testScope)
-        {
-            lock (_scopeLock)
-            {
-                if (_currentScope.ActiveScopes.Contains(testScope))
-                    _currentScope = testScope.PreviousScope;
-                //Else the test scope had already been exited - we could throw an exception here
-            }
-        }
-
-        private sealed class TestScope : IDisposable
-        {
-            //This class is nested so that it can access the EndScope method
-            public TestSink TestSink { get; }
-
-            public (IReadOnlyCollection<BeginScope> ScopeData, IReadOnlyCollection<TestScope> ActiveScopes) PreviousScope { get; }
-
-            public TestScope(TestSink testSink, (IReadOnlyCollection<BeginScope> ScopeData, IReadOnlyCollection<TestScope> ActiveScopes) previousScope)
-            {
-                TestSink = testSink;
-                PreviousScope = previousScope;
-            }
-
-            private bool _disposed = false;
-
-            /// <inheritdoc />
-            public void Dispose()
-            {
-                if (_disposed) return;
-                _disposed = true;
-                TestSink.EndScope(this);
-            }
         }
     }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/MELT/WriteContext.cs
+++ b/src/MELT/WriteContext.cs
@@ -11,7 +11,7 @@ namespace MELT
     public readonly struct WriteContext
     {
         public WriteContext(LogLevel logLevel, EventId eventId, object? state, Exception? exception, object? scope,
-            string loggerName, string? message, IEnumerable<IScope> fullScope)
+            string loggerName, string? message, IEnumerable<object?> scopes)
         {
             LogLevel = logLevel;
             EventId = eventId;
@@ -20,7 +20,7 @@ namespace MELT
             Scope = scope;
             LoggerName = loggerName;
             Message = message;
-            FullScope = fullScope;
+            Scopes = scopes;
         }
 
         public LogLevel LogLevel { get; }
@@ -34,7 +34,7 @@ namespace MELT
         /// <summary>
         /// The most recent scope to have been created by the logger.
         /// </summary>
-        [Obsolete("Use FullScope instead")]
+        [Obsolete("The preferred alternative is " + nameof(Scopes) + ".")]
         public object? Scope { get; }
 
         public string LoggerName { get; }
@@ -44,6 +44,6 @@ namespace MELT
         /// <summary>
         /// The full scope when the event was logged.
         /// </summary>
-        public IEnumerable<IScope> FullScope { get; }
+        public IEnumerable<object?> Scopes { get; }
     }
 }

--- a/test/MELT.Tests/ScopeTests.cs
+++ b/test/MELT.Tests/ScopeTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -94,9 +98,9 @@ namespace MELT.Tests
             //Assert
             var expectations = new List<(string expectedMessage, string[] expectedScopes)>()
             {
-                ("Message 1", new []{"Outer Scope"} ),
-                ("Message 2", new []{"Inner Scope","Outer Scope"} ),
-                ("Message 3", new []{"Outer Scope"} )
+                ("Message 1", new []{ "Outer Scope" } ),
+                ("Message 2", new []{ "Outer Scope", "Inner Scope" } ),
+                ("Message 3", new []{ "Outer Scope" } )
             };
 
             Assert.Equal(expectations.Count, loggerFactory.Sink.LogEntries.Count());
@@ -110,7 +114,7 @@ namespace MELT.Tests
         }
 
         [Fact]
-        public void ClosingAScope_ShouldCloseAllInnerScopes()
+        public void ClosingAScope_ShouldCloseAllInnerScopes_AndRestoreParentScope()
         {
             //Arrange
             var loggerFactory = TestLoggerFactory.Create();
@@ -123,21 +127,24 @@ namespace MELT.Tests
             logger.LogInformation("Message 2");
             var scopeC = logger.BeginScope("Scope C");
             logger.LogInformation("Message 3");
+            // Disposing B also removes C
             scopeB.Dispose();
             logger.LogInformation("Message 4");
+            // Disposing C restore B (as well as its parent A)
             scopeC.Dispose();
             logger.LogInformation("Message 5");
+            // Disposing A also removes B
             scopeA.Dispose();
             logger.LogInformation("Message 6");
 
             //Assert
             var expectations = new List<(string expectedMessage, string[] expectedScopes)>()
             {
-                ("Message 1", new []{"Scope A"} ),
-                ("Message 2", new []{"Scope B","Scope A"} ),
-                ("Message 3", new []{"Scope C", "Scope B","Scope A"} ),
-                ("Message 4", new []{"Scope A"} ),
-                ("Message 5", new []{"Scope A"} ),
+                ("Message 1", new []{ "Scope A" } ),
+                ("Message 2", new []{ "Scope A", "Scope B" } ),
+                ("Message 3", new []{ "Scope A", "Scope B","Scope C"} ),
+                ("Message 4", new []{ "Scope A" } ),
+                ("Message 5", new []{ "Scope A", "Scope B" } ),
                 ("Message 6", new string[]{} ),
             };
 
@@ -162,27 +169,31 @@ namespace MELT.Tests
             //Act
             using (loggerA.BeginScope("A Scope"))
             {
-                loggerA.LogInformation("Message 1");
+                loggerA.LogInformation("Message A1");
+                loggerB.LogInformation("Message B1");
                 using (loggerB.BeginScope("B Scope"))
                 {
-                    loggerA.LogInformation("Message 2");
+                    loggerA.LogInformation("Message A2");  // only in A as B is in different logger
+                    loggerB.LogInformation("Message B2");
                 }
-                loggerA.LogInformation("Message 3");
-                loggerB.LogInformation("Message 4");
+                loggerA.LogInformation("Message A3");
+                loggerB.LogInformation("Message B3");
             }
 
-            loggerA.LogInformation("Message 5");
-            loggerB.LogInformation("Message 6");
+            loggerA.LogInformation("Message A4");
+            loggerB.LogInformation("Message B4");
 
             //Assert
             var expectations = new List<(string expectedMessage, string[] expectedScopes)>()
             {
-                ("Message 1", new []{"A Scope"} ),
-                ("Message 2", new []{"B Scope","A Scope"} ),
-                ("Message 3", new []{"A Scope"} ),
-                ("Message 4", new []{"A Scope"} ),
-                ("Message 5", Array.Empty<string>() ),
-                ("Message 6", Array.Empty<string>() ),
+                ("Message A1", new []{ "A Scope" } ),
+                ("Message B1", Array.Empty<string>() ),
+                ("Message A2", new []{ "A Scope" } ),
+                ("Message B2", new []{ "B Scope" } ),
+                ("Message A3", new []{ "A Scope" } ),
+                ("Message B3", Array.Empty<string>() ),
+                ("Message A4", Array.Empty<string>() ),
+                ("Message B4", Array.Empty<string>() ),
             };
 
             Assert.Equal(expectations.Count, loggerFactory.Sink.LogEntries.Count());
@@ -193,6 +204,67 @@ namespace MELT.Tests
                 Assert.Equal(expectedScope, logEntry.Scopes.Select(x => x.Message));
                 Assert.Equal(expectedMessage, logEntry.Message);
             }
+        }
+
+        [Fact]
+        public async Task MessagesLoggedInScopesInDifferentAsyncScopes_ShouldHaveCorrectScopes()
+        {
+            async Task DoAsync(SemaphoreSlim scopeCreated, SemaphoreSlim ready, ILogger logger, string name, CancellationToken cancellationToken)
+            {
+                using (logger.BeginScope(name))
+                {
+                    scopeCreated.Release();
+                    await ready.WaitAsync(cancellationToken);
+                    logger.LogInformation(name);
+                }
+            }
+
+            //Arrange
+            var loggerFactory = TestLoggerFactory.Create();
+            var logger = loggerFactory.CreateLogger("Test");
+            var semaphoreA = new SemaphoreSlim(0, 1);
+            var semaphoreB = new SemaphoreSlim(0, 1);
+            using var cts = Debugger.IsAttached ? new CancellationTokenSource() : new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+            //Act
+            var taskA = DoAsync(semaphoreB, semaphoreA, logger, "A", cts.Token);
+            var taskB = DoAsync(semaphoreA, semaphoreB, logger, "B", cts.Token);
+
+            await Task.WhenAll(taskA, taskB);
+
+            //Assert
+            Assert.Equal(2, loggerFactory.Sink.LogEntries.Count());
+            Assert.All(loggerFactory.Sink.LogEntries,
+                x => Assert.Equal(x.Message, x.Scopes.Select(x => x.Message).Single()));
+        }
+
+        [Fact]
+        public void MessageLoggedInsideScopeWithProperties_ShouldHaveScopeWithProperties()
+        {
+            //Arrange
+            var loggerFactory = TestLoggerFactory.Create();
+            var logger = loggerFactory.CreateLogger("Test");
+
+            //Act
+            using (logger.BeginScope(new Dictionary<string, object>
+            {
+                ["foo"] = "bar",
+                ["answer"] = 42
+            }))
+            {
+                logger.LogInformation("Message 1");
+            }
+
+            //Assert
+            var entry = Assert.Single(loggerFactory.Sink.LogEntries);
+            var scope = Assert.Single(entry.Scopes);
+
+            Assert.Equal(new Dictionary<string, object>
+            {
+                ["foo"] = "bar",
+                ["answer"] = 42
+            }, scope.Properties);
+            Assert.Equal("Message 1", entry.Message);
         }
     }
 }

--- a/test/MELT.Tests/ScopeTests.cs
+++ b/test/MELT.Tests/ScopeTests.cs
@@ -209,7 +209,8 @@ namespace MELT.Tests
         [Fact]
         public async Task MessagesLoggedInScopesInDifferentAsyncScopes_ShouldHaveCorrectScopes()
         {
-            async Task DoAsync(SemaphoreSlim scopeCreated, SemaphoreSlim ready, ILogger logger, string name, CancellationToken cancellationToken)
+            static async Task LogAsync(SemaphoreSlim scopeCreated, SemaphoreSlim ready, ILogger logger,
+                string name, CancellationToken cancellationToken)
             {
                 using (logger.BeginScope(name))
                 {
@@ -227,8 +228,8 @@ namespace MELT.Tests
             using var cts = Debugger.IsAttached ? new CancellationTokenSource() : new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
             //Act
-            var taskA = DoAsync(semaphoreB, semaphoreA, logger, "A", cts.Token);
-            var taskB = DoAsync(semaphoreA, semaphoreB, logger, "B", cts.Token);
+            var taskA = LogAsync(semaphoreB, semaphoreA, logger, "A", cts.Token);
+            var taskB = LogAsync(semaphoreA, semaphoreB, logger, "B", cts.Token);
 
             await Task.WhenAll(taskA, taskB);
 

--- a/test/MELT.Tests/ScopeTests.cs
+++ b/test/MELT.Tests/ScopeTests.cs
@@ -24,7 +24,7 @@ namespace MELT.Tests
 
             //Assert
             var entry = Assert.Single(loggerFactory.Sink.LogEntries);
-            var scope = Assert.Single(entry.FullScope);
+            var scope = Assert.Single(entry.Scopes);
 
             Assert.Equal("Scope 1", scope.Message);
             Assert.Equal("Message 1", entry.Message);
@@ -46,7 +46,7 @@ namespace MELT.Tests
             //Assert
             var entry = Assert.Single(loggerFactory.Sink.LogEntries);
 
-            Assert.Empty(entry.FullScope);
+            Assert.Empty(entry.Scopes);
             Assert.Equal("Message 1", entry.Message);
         }
 
@@ -69,7 +69,7 @@ namespace MELT.Tests
             //Assert
             var entry = Assert.Single(loggerFactory.Sink.LogEntries);
 
-            Assert.Equal(new[] { "Scope 2", "Scope 1" }, entry.FullScope.Select(x => x.Message));
+            Assert.Equal(new[] { "Scope 1", "Scope 2" }, entry.Scopes.Select(x => x.Message));
             Assert.Equal("Message 1", entry.Message);
         }
 
@@ -104,7 +104,7 @@ namespace MELT.Tests
             foreach (var (logEntry, (expectedMessage, expectedScope)) in loggerFactory.Sink.LogEntries.Zip(expectations))
             {
                 Assert.Equal(logEntry.Message, expectedMessage);
-                Assert.Equal(expectedScope, logEntry.FullScope.Select(x => x.Message));
+                Assert.Equal(expectedScope, logEntry.Scopes.Select(x => x.Message));
                 Assert.Equal(expectedMessage, logEntry.Message);
             }
         }
@@ -146,7 +146,7 @@ namespace MELT.Tests
             foreach (var (logEntry, (expectedMessage, expectedScope)) in loggerFactory.Sink.LogEntries.Zip(expectations))
             {
                 Assert.Equal(logEntry.Message, expectedMessage);
-                Assert.Equal(expectedScope, logEntry.FullScope.Select(x => x.Message));
+                Assert.Equal(expectedScope, logEntry.Scopes.Select(x => x.Message));
                 Assert.Equal(expectedMessage, logEntry.Message);
             }
         }
@@ -190,7 +190,7 @@ namespace MELT.Tests
             foreach (var (logEntry, (expectedMessage, expectedScope)) in loggerFactory.Sink.LogEntries.Zip(expectations))
             {
                 Assert.Equal(logEntry.Message, expectedMessage);
-                Assert.Equal(expectedScope, logEntry.FullScope.Select(x => x.Message));
+                Assert.Equal(expectedScope, logEntry.Scopes.Select(x => x.Message));
                 Assert.Equal(expectedMessage, logEntry.Message);
             }
         }


### PR DESCRIPTION
This is a follow-up of #25. I've investigated the behaviour of the default Microsoft loggers (and some 3rd party ones) and the scopes are local not only to the logger, but also to the async context (which now of course makes sense).

I've moved the implementation from the sink to the logger and reworked it to be local to an async local, using a linked list stored in a `AsyncLocal`, similarly to the implementation of the [LoggerExternalScopeProvider of Microsoft.Extensions.Logging](https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerExternalScopeProvider.cs)

I've also renamed the property to access the scopes and reversed the list to be in the opening order as I feel it is more intuitive.

Finally, I've changed the behaviour of the obsolete `LogEntry.Scope` property, to return the latest active scope, as I find it hard to find a use case for the old behaviour (if really needed, in simple scenarios with a single logger can be replicate with `TestSink.Scopes`). Will consider adding it back later if requested.

Fixes #24

/cc @wainwrightmark 