### PR TITLE
Adds missing XML comments and made sink backing field private

### DIFF
--- a/src/MELT/Helpers/BeginScope.cs
+++ b/src/MELT/Helpers/BeginScope.cs
@@ -22,7 +22,7 @@ namespace MELT
         }
 
         /// <summary>
-        ///
+        /// Gets the name of the logger associated with this scope.
         /// </summary>
         public string? LoggerName => _scope.LoggerName;
 

--- a/src/MELT/Helpers/BeginScope.cs
+++ b/src/MELT/Helpers/BeginScope.cs
@@ -8,17 +8,21 @@ namespace MELT
     /// </summary>
     public class BeginScope : IScope
     {
+#pragma warning disable CS0612 // Type or member is obsolete
         private readonly BeginScopeContext _scope;
+#pragma warning restore CS0612 // Type or member is obsolete
         private string? _format;
         private static readonly KeyValuePair<string, object>[] _emptyProperties = new KeyValuePair<string, object>[0];
 
+#pragma warning disable CS0612 // Type or member is obsolete
         internal BeginScope(BeginScopeContext scope)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             _scope = scope;
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public string? LoggerName => _scope.LoggerName;
 

--- a/src/MELT/Helpers/LogEntry.cs
+++ b/src/MELT/Helpers/LogEntry.cs
@@ -55,6 +55,9 @@ namespace MELT
         /// </summary>
         public string OriginalFormat => _format ??= Properties.GetOriginalFormat();
 
+        /// <summary>
+        /// The format string for this log entry. Prefer using <see cref="OriginalFormat"/>.
+        /// </summary>
         [Obsolete("The preferred alternative is " + nameof(OriginalFormat) + ".")]
         public string Format => OriginalFormat;
 

--- a/src/MELT/Helpers/MELTLoggingBuilderExtensions.cs
+++ b/src/MELT/Helpers/MELTLoggingBuilderExtensions.cs
@@ -4,12 +4,26 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.Logging
 {
+    /// <summary>
+    /// Provides extension methods for adding MELT test logging interceptors to an <see cref="ILoggingBuilder"/>.
+    /// </summary>
     public static class MELTLoggingBuilderExtensions
     {
+        /// <summary>
+        /// Adds a test logger provider to the specified <see cref="ILoggingBuilder"/> with default settings.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+        /// <returns>The <see cref="ILoggingBuilder"/> for chaining.</returns>
         [Obsolete]
         public static ILoggingBuilder AddTestLogger(this ILoggingBuilder builder)
             => builder.AddTestLogger(MELTBuilder.CreateTestSink());
 
+        /// <summary>
+        /// Adds a test logger provider to the specified <see cref="ILoggingBuilder"/> with custom configuration options.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+        /// <param name="configure">An action to configure the <see cref="TestLoggerOptions"/>.</param>
+        /// <returns>The <see cref="ILoggingBuilder"/> for chaining.</returns>
         [Obsolete("The recommended alternative is " + nameof(AddTest) + "(Action<" + nameof(TestLoggerOptions) + ">) or use the simplified factory.WithWebHostBuilder(builder => builder.UseTestLogging()). The sink can then be retrieved with factory.GetTestLoggerSink()")]
         public static ILoggingBuilder AddTestLogger(this ILoggingBuilder builder, Action<TestLoggerOptions> configure)
         {
@@ -31,6 +45,12 @@ namespace Microsoft.Extensions.Logging
         //    return builder.AddProvider(new TestLoggerProvider(sinkWrapper.Sink));
         //}
 
+        /// <summary>
+        /// Adds a test logger provider to the specified <see cref="ILoggingBuilder"/> using the provided <see cref="ITestSink"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+        /// <param name="sink">The <see cref="ITestSink"/> to use for logging.</param>
+        /// <returns>The <see cref="ILoggingBuilder"/> for chaining.</returns>
         [Obsolete("The recommended alternative is " + nameof(AddTest) + "() or use the simplified factory.WithWebHostBuilder(builder => builder.UseTestLogging()). The sink can then be retrieved with factory.GetTestLoggerSink()")]
         public static ILoggingBuilder AddTestLogger(this ILoggingBuilder builder, ITestSink sink)
         {
@@ -38,9 +58,20 @@ namespace Microsoft.Extensions.Logging
             return builder.AddProvider(new TestLoggerProvider(sink));
         }
 
+        /// <summary>
+        /// Adds a test logger provider to the specified <see cref="ILoggingBuilder"/> with default options.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+        /// <returns>The <see cref="ILoggingBuilder"/> for chaining.</returns>
         public static ILoggingBuilder AddTest(this ILoggingBuilder builder)
             => builder.AddTestLoggerProvider(new TestLoggerOptions());
 
+        /// <summary>
+        /// Adds a test logger provider to the specified <see cref="ILoggingBuilder"/> with custom configuration options.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+        /// <param name="configure">An action to configure the <see cref="TestLoggerOptions"/>.</param>
+        /// <returns>The <see cref="ILoggingBuilder"/> for chaining.</returns>
         public static ILoggingBuilder AddTest(this ILoggingBuilder builder, Action<TestLoggerOptions> configure)
         {
             if (configure == null) throw new ArgumentNullException(nameof(configure));
@@ -54,9 +85,13 @@ namespace Microsoft.Extensions.Logging
             var sink = MELTBuilder.CreateTestSink(options);
 
             builder.Services.TryAddSingleton(sink);
+#pragma warning disable CS0612 // Type or member is obsolete
             builder.Services.TryAddSingleton<IInternalTestSink>(sink);
+#pragma warning restore CS0612 // Type or member is obsolete
             builder.Services.TryAddTransient<ITestLoggerSink, TestLoggerSinkAccessor>();
+#pragma warning disable CS0618 // Type or member is obsolete
             return builder.AddProvider(new TestLoggerProvider(sink));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/MELT/TestLoggerProvider.cs
+++ b/src/MELT/TestLoggerProvider.cs
@@ -10,28 +10,44 @@ namespace MELT
     [ProviderAlias("TestLogger")]
     public class TestLoggerProvider : ITestLoggerProvider
     {
-        public readonly ITestSink _sink;
+#pragma warning disable CS0612 // Type or member is obsolete
+        private readonly ITestSink _sink;
+#pragma warning restore CS0612 // Type or member is obsolete
 
         // TODO: keep as internal for testing
-        [Obsolete]
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestLoggerProvider"/> class with the specified <see cref="ITestSink"/>.
+        /// </summary>
+        /// <param name="sink">The <see cref="ITestSink"/> to use for logging.</param>
+        /// <remarks>
+        /// This constructor is obsolete. Use the parameterless constructor instead.
+        /// </remarks>
+        [Obsolete("This constructor is obsolete. Use the parameterless constructor instead.")]
         public TestLoggerProvider(ITestSink sink)
         {
             _sink = sink;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestLoggerProvider"/> class with a default <see cref="ITestLoggerSink"/>.
+        /// </summary>
         public TestLoggerProvider()
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             _sink = new TestSink();
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         /// <inheritdoc/>
         public ITestLoggerSink Sink => _sink;
 
+        /// <inheritdoc/>
         public ILogger CreateLogger(string categoryName)
         {
             return new TestLogger(categoryName, _sink);
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
         }


### PR DESCRIPTION
This PR adds missing XML comments to improve code documentation and refactors the access modifier of a sink backing field to enhance encapsulation.

- Updated XML documentation for constructors, properties, and extension methods
- Changed the accessibility of the sink backing field from public to private
- Added pragma directives to suppress obsolete warnings in a controlled manner